### PR TITLE
v0.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Changelog
 
+### Release v0.2 `15/07/2021`
+
+This change is so that we have more visibility over the request to fetch an accessToken and the Guzzle response body of that request.
+- The session storage of a valid accessToken has been removed. We cannot go down the route of caching/refreshing the token continuously, so we now request a fresh token each time we make a request.
+- In cases where the call to `/api/accessToken` does not return a valid accessToken response (eg. [here](https://github.com/LBHounslow/hounslow-api-client-jadu/blob/develop/src/Client/Client.php#L320)), the Guzzle response body is stored in [ApiException->getResponseBody()](https://github.com/LBHounslow/hounslow-api-client-jadu/blob/develop/src/Exception/ApiException.php#L49) and is available for logging purposes so we can debug issues.
+
 ### Release v0.1 `14/07/2021`
 
 This is the first release. It is based on the [v0.4 release](https://github.com/LBHounslow/hounslow-api-client/releases/tag/v0.4) of the [Hounslow API Client](https://github.com/LBHounslow/hounslow-api-client) which was a specific release for Jadu compatibility. Going forward this will be the Jadu specific version of the Hounslow API Client. 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ This repository is currently closed for contribution. Please [report an an issue
 
 ### Tests
 
-There are 35 tests with 97 assertions.
+There are 25 tests with 77 assertions.
 
 Run `./vendor/bin/phpunit tests`

--- a/example.php
+++ b/example.php
@@ -30,6 +30,7 @@ try {
 } catch (ApiException $e) {
     // Handle the exception error (http status code is available)
     $httpStatusCode = $e->getStatusCode();
+    $responseBody = $e->getResponseBody(); // will contain guzzle response body
     $response = null;
 }
 

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -12,19 +12,27 @@ class ApiException extends \Exception
     private $statusCode;
 
     /**
+     * @var string
+     */
+    private $responseBody;
+
+    /**
      * @param int $statusCode
      * @param string $message
+     * @param string $responseBody
      * @param int $code
      * @param Throwable|null $previous
      */
     public function __construct(
         int $statusCode,
-        string $message = "",
+        string $message = '',
+        string $responseBody = '',
         int $code = 0,
         Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->statusCode = $statusCode;
+        $this->responseBody = $responseBody;
     }
 
     /**
@@ -33,5 +41,13 @@ class ApiException extends \Exception
     public function getStatusCode()
     {
         return $this->statusCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponseBody()
+    {
+        return $this->responseBody;
     }
 }

--- a/tests/unit/Exception/ApiExceptionTest.php
+++ b/tests/unit/Exception/ApiExceptionTest.php
@@ -10,7 +10,7 @@ class ApiExceptionTest extends ApiClientTestCase
 {
     public function testItSetsStatusCodeCorrectly()
     {
-        $result = new ApiException(HttpStatusCodeEnum::BAD_REQUEST, 'error', 13);
+        $result = new ApiException(HttpStatusCodeEnum::BAD_REQUEST, 'error', '{"unexpected":"response"}', 13);
         $this->assertInstanceOf(\Exception::class, $result);
         $this->assertEquals(HttpStatusCodeEnum::BAD_REQUEST, $result->getStatusCode());
         $this->assertEquals('error', $result->getMessage());


### PR DESCRIPTION
This change is so that we have more visibility over the request to fetch an accessToken and the Guzzle response body of that request.
- The session storage of a valid accessToken has been removed. We cannot go down the route of caching/refreshing the token continuously, so we now request a fresh token each time we make a request.
- In cases where the call to `/api/accessToken` does not return a valid accessToken response (eg. [here](https://github.com/LBHounslow/hounslow-api-client-jadu/blob/develop/src/Client/Client.php#L320)), the Guzzle response body is stored in [ApiException->getResponseBody()](https://github.com/LBHounslow/hounslow-api-client-jadu/blob/develop/src/Exception/ApiException.php#L49) and is available for logging purposes so we can debug issues.

```
PHPUnit 9.5.5 by Sebastian Bergmann and contributors.
.........................                                         25 / 25 (100%)

Time: 00:00.074, Memory: 8.00 MB

OK (25 tests, 77 assertions)
```